### PR TITLE
Autosave on race stop

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,10 @@ Allows the race director to start the race from their transmitter. Please naviga
 
 Allows the race director to stop the race from their transmitter. Please navigate [here](https://github.com/i-am-grub/VRxC_ELRS#control-the-race-from-the-race-directors-transmitter) for binding the backpack.
 
+### Autosave on stop : CHECKBOX
+
+Automatically save the race when stopping from the transmitter
+
 ### Backpack Rescan : BUTTON
 
 Triggers the timer to scan the serial devices for a backpack device. Only works if the timer is not already connected to a backpack device

--- a/custom_plugins/vrxc_elrs/__init__.py
+++ b/custom_plugins/vrxc_elrs/__init__.py
@@ -66,6 +66,7 @@ def initialize(rhapi: RHAPI.RHAPI):
         "Autosave on stop",
         desc="Automatically save the race when stopping from the transmitter",
         field_type=UIFieldType.CHECKBOX,
+        value="0",
     )
     rhapi.fields.register_option(_autosave_on_stop, "elrs_settings")
 

--- a/custom_plugins/vrxc_elrs/__init__.py
+++ b/custom_plugins/vrxc_elrs/__init__.py
@@ -61,6 +61,14 @@ def initialize(rhapi: RHAPI.RHAPI):
     )
     rhapi.fields.register_option(_race_stop, "elrs_settings")
 
+    _autosave_on_stop = UIField(
+        "_autosave_on_stop",
+        "Autosave on stop",
+        desc="Automatically save the race when stopping from the transmitter",
+        field_type=UIFieldType.CHECKBOX,
+    )
+    rhapi.fields.register_option(_autosave_on_stop, "elrs_settings")
+
     _socket_ip = UIField(
         "_socket_ip",
         "ELRS Netpack Address",

--- a/custom_plugins/vrxc_elrs/elrs_backpack.py
+++ b/custom_plugins/vrxc_elrs/elrs_backpack.py
@@ -58,7 +58,10 @@ class ELRSBackpack(VRxController):
         if self._rhapi.db.option("_race_stop") == "1":
             status = self._rhapi.race.status
             if status in (RaceStatus.STAGING, RaceStatus.RACING):
-                self._rhapi.race.stop()
+                if self._rhapi.db.option("_autosave_on_stop") == "1":
+                    self._rhapi.race.save()
+                else:
+                    self._rhapi.race.stop()
 
     #
     # Connection handling


### PR DESCRIPTION
This adds a new checkbox under the plugin settings "Autosave on stop" (disabled by default). This allows restating runs, useful when Rotorhazard is used as a personal timer.