### PR TITLE
Fix plugin not starting beause of imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,10 @@ Allows the race director to start the race from their transmitter. Please naviga
 
 Allows the race director to stop the race from their transmitter. Please navigate [here](https://github.com/i-am-grub/VRxC_ELRS#control-the-race-from-the-race-directors-transmitter) for binding the backpack.
 
+### Autosave on stop : CHECKBOX
+
+Automatically save the race when stopping from the transmitter
+
 ### Backpack Rescan : BUTTON
 
 Triggers the timer to scan the serial devices for a backpack device. Only works if the timer is not already connected to a backpack device

--- a/custom_plugins/vrxc_elrs/__init__.py
+++ b/custom_plugins/vrxc_elrs/__init__.py
@@ -66,6 +66,7 @@ def initialize(rhapi: RHAPI.RHAPI):
         "Autosave on stop",
         desc="Automatically save the race when stopping from the transmitter",
         field_type=UIFieldType.CHECKBOX,
+        value="0",
     )
     rhapi.fields.register_option(_autosave_on_stop, "elrs_settings")
 

--- a/custom_plugins/vrxc_elrs/__init__.py
+++ b/custom_plugins/vrxc_elrs/__init__.py
@@ -61,6 +61,14 @@ def initialize(rhapi: RHAPI.RHAPI):
     )
     rhapi.fields.register_option(_race_stop, "elrs_settings")
 
+    _autosave_on_stop = UIField(
+        "_autosave_on_stop",
+        "Autosave on stop",
+        desc="Automatically save the race when stopping from the transmitter",
+        field_type=UIFieldType.CHECKBOX,
+    )
+    rhapi.fields.register_option(_autosave_on_stop, "elrs_settings")
+
     _socket_ip = UIField(
         "_socket_ip",
         "ELRS Netpack Address",

--- a/custom_plugins/vrxc_elrs/connections.py
+++ b/custom_plugins/vrxc_elrs/connections.py
@@ -7,7 +7,7 @@ import gevent
 import gevent.queue
 import gevent.socket as socket
 import serial
-from serial.tools.list_ports
+import serial.tools.list_ports
 from gevent.queue import Queue
 
 from .msp import MSPPacket, MSPPacketType, MSPTypes

--- a/custom_plugins/vrxc_elrs/connections.py
+++ b/custom_plugins/vrxc_elrs/connections.py
@@ -7,6 +7,7 @@ import gevent
 import gevent.queue
 import gevent.socket as socket
 import serial
+from serial.tools.list_ports
 from gevent.queue import Queue
 
 from .msp import MSPPacket, MSPPacketType, MSPTypes

--- a/custom_plugins/vrxc_elrs/elrs_backpack.py
+++ b/custom_plugins/vrxc_elrs/elrs_backpack.py
@@ -58,7 +58,10 @@ class ELRSBackpack(VRxController):
         if self._rhapi.db.option("_race_stop") == "1":
             status = self._rhapi.race.status
             if status in (RaceStatus.STAGING, RaceStatus.RACING):
-                self._rhapi.race.stop()
+                if self._rhapi.db.option("_autosave_on_stop") == "1":
+                    self._rhapi.race.save()
+                else:
+                    self._rhapi.race.stop()
 
     #
     # Connection handling


### PR DESCRIPTION
Just tried to install on a fresh RPI, it fails to start with:

```
2025-09-02 15:32:55.513: [ERROR] RHUtils Exception via catchLogExceptionsWrapper
Traceback (most recent call last):
  File "/home/rotorhazard/RotorHazard/src/server/RHUtils.py", line 338, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/rotorhazard/RotorHazard/src/server/eventmanager.py", line 101, in run_handler
    return handler(args)
           ^^^^^^^^^^^^^
  File "/home/rotorhazard/RotorHazard/src/server/RHUI.py", line 285, in dispatch_quickbuttons
    btn.fn(btn.args)
  File "/home/rotorhazard/rh-data/plugins/vrxc_elrs/elrs_backpack.py", line 93, in start_connection
    self._establish_connection(con.type_)
  File "/home/rotorhazard/rh-data/plugins/vrxc_elrs/elrs_backpack.py", line 136, in _establish_connection
    if not self._connection.connect(**kwargs):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rotorhazard/rh-data/plugins/vrxc_elrs/connections.py", line 70, in connect
    avaliable_port = {port.device for port in serial.tools.list_ports.comports()}
                                              ^^^^^^^^^^^^
AttributeError: module 'serial' has no attribute 'tools'
```

More contexT: https://discord.com/channels/922611186476924970/1066081652037664829/1381781529214193847