### PR TITLE
fix: plugin does not start because of wrong import

### DIFF
--- a/custom_plugins/vrxc_elrs/connections.py
+++ b/custom_plugins/vrxc_elrs/connections.py
@@ -7,6 +7,7 @@ import gevent
 import gevent.queue
 import gevent.socket as socket
 import serial
+import serial.tools.list_ports
 from gevent.queue import Queue
 
 from .msp import MSPPacket, MSPPacketType, MSPTypes


### PR DESCRIPTION
Fixing plugin not staring because of missing imports